### PR TITLE
Workarround das "Configure WIFI" nicht gezeigt wird beim ESP Webinstaller

### DIFF
--- a/src/HomeStatusDisplay.cpp
+++ b/src/HomeStatusDisplay.cpp
@@ -50,7 +50,10 @@ void HomeStatusDisplay::onImprovWiFiErrorCb(ImprovTypes::Error err)
   
   if(err == ImprovTypes::Error::ERROR_WIFI_CONNECT_GIVEUP) {
     Serial.println("Giving up on connecting to WiFi, restart the device");
+    if (!m_config.getChipFamily()==4)
+    {
     ESP.restart();
+    };
   }
 }
 


### PR DESCRIPTION
Der eigentliche Fehler ist, dass der ESP8266 versucht sich zu verbinden obwohl er keine SSID und Passwort hat. Dies schlägt dann 120 mal fehl und es wird die Fehlermeldung "ERROR_WIFI_CONNECT_GIVEUP" ausgegeben woraufhin der ESP neu gebootet wird. Da dies im ca. 2 Sekunden Takt passiert kann keine Improv Serial Verbindung aufgebaut werden um die WIFI Daten einzugeben. Der Workarrount fragt ab ob "ChipFamily" = 4 (ESP8266) ist und verhindert dann den Reboot. Dadurch wird mittels Improv eine Serielle Verbindung zum ESP8266 aufgebaut und man kann die SSID auswählen und das Passwort eingeben.